### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/raspberryPi/ultrasonic_client.py
+++ b/raspberryPi/ultrasonic_client.py
@@ -47,7 +47,7 @@ GPIO.output(GPIO_TRIGGER, False)
 try:
     while True:
         distance = measure()
-        print "Distance : %.1f cm" % distance
+        print("Distance : %.1f cm" % distance)
         # send data to the host every 0.5 sec
         client_socket.send(str(distance).encode('utf-8'))
         time.sleep(0.5)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.