### PR TITLE
docs: fix simple typo, aiticle -> article

### DIFF
--- a/arduino/README.md
+++ b/arduino/README.md
@@ -1,1 +1,1 @@
-Inspired by this aiticle: [Drive a Lamborghini With Your Keyboard](http://thelivingpearl.com/2013/01/04/drive-a-lamborghini-with-your-keyboard/)
+Inspired by this article: [Drive a Lamborghini With Your Keyboard](http://thelivingpearl.com/2013/01/04/drive-a-lamborghini-with-your-keyboard/)


### PR DESCRIPTION
There is a small typo in arduino/README.md.

Should read `article` rather than `aiticle`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md